### PR TITLE
Removed internal IP address

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -10,7 +10,7 @@ export default {
   api: {
     location: {
       protocal: 'http',
-      host: '10.3.49.134',
+      host: 'localhost', //or another Kronos root IP or address
       basepath: '/wfc/XmlService'
     },
   },


### PR DESCRIPTION
Hi there! I was browsing through this really intriguing implementation against Kronos (thanks for open sourcing this code and showing what's possible against the Kronos API) and noticed that there may be an internal IP address listed in your configs.
d
I figured while I was here I'd remove in favor of a more generic address and add a comment. Feel free to reject / close if it's not going to work for you.

Thanks again and have a good one.